### PR TITLE
Update block-reader.js

### DIFF
--- a/events/block-reader.js
+++ b/events/block-reader.js
@@ -23,7 +23,10 @@ const getMinimal = pastEvents => {
 
 module.exports.getEvents = async symbol => {
   const directory = Parameters.eventsDownloadFolder.replace(/{token}/g, symbol);
-  const files = await readdirAsync(directory);
+  var files = await readdirAsync(directory);
+  files.sort((a,b) => {
+    return parseInt(a.split(".")[0]) - parseInt(b.split(".")[0]);
+  });
   let events = [];
 
   console.log("Parsing files.");


### PR DESCRIPTION
Sort the files by block height before parsing. (Int comparison)

Had some issues with the default alphabetic sort as newer blocks with more characters get parsed first. E.g (10000000 -> 9999999)